### PR TITLE
Printer cleanup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ pdf/simulatedsio/.pio/build/project.checksum
 pdf/simulatedsio/.pio/build/windows_x86/.sconsign.py*
 pdf/simulatedsio/.pio/build/windows_x86/program.exe
 
+platformio/FujiNet/fuijnet.code-workspace

--- a/platformio/FujiNet/fuijnet.code-workspace
+++ b/platformio/FujiNet/fuijnet.code-workspace
@@ -2,9 +2,6 @@
 	"folders": [
 		{
 			"path": "."
-		},
-		{
-			"path": "C:\\Users\\Jeff\\Documents\\GitHub\\atariwifi\\pdf\\simulatedsio"
 		}
 	],
 	"settings": {

--- a/platformio/FujiNet/lib/sio/printer.cpp
+++ b/platformio/FujiNet/lib/sio/printer.cpp
@@ -105,10 +105,10 @@ void sioPrinter::initPDF(File *f)
 void sioPrinter::formFeed()
 {
   //todo : spit out blank lines to fill up page
-  /*   while (pdf_lineCounter < maxLines)
+    while (pdf_lineCounter < maxLines)
   {
     pdf_add_line("");
-  } */
+  }
   pdf_xref();
 }
 

--- a/platformio/FujiNet/lib/sio/printer.cpp
+++ b/platformio/FujiNet/lib/sio/printer.cpp
@@ -49,15 +49,22 @@ void sioPrinter::pdf_xref()
   _file->printf("%d\n", xref);
   _file->printf("%%%%EOF\n");
 }
-void sioPrinter::pdf_add_line(const char *L)
+void sioPrinter::pdf_add_line(std::string L)
 {
+  int le=L.length();
   // to do: handle odd characters for fprintf, e.g., %,'," etc.
   pdf_objCtr++;
   objLocations[pdf_objCtr] = objLocations[pdf_objCtr - 1] + pdf_offset;
-  pdf_offset = _file->printf("%d 0 obj <</Length %d>> stream\n", pdf_objCtr, 30 + strlen(L));
+  pdf_offset = _file->printf("%d 0 obj <</Length %d>> stream\n", pdf_objCtr, 30 + le);
   int xcoord = pageHeight - lineHeight + bottomMargin - pdf_lineCounter * lineHeight;
   //this string right here vvvvvv is 30 chars long plus the length of the payload
-  pdf_offset += _file->printf("BT /F1 %2d Tf %2d %3d Td (%s)Tj ET\n", fontSize, leftMargin, xcoord, L);
+  pdf_offset += _file->printf("BT /F1 %2d Tf %2d %3d Td (",fontSize, leftMargin, xcoord);
+  pdf_offset += le;
+  for (int i=0;i<le;i++)
+  {
+    _file->write((byte)L[i]);
+  }
+  pdf_offset += _file->printf(")Tj ET\n");
   pdf_offset += _file->printf("endstream endobj\n");
 }
 void sioPrinter::atari_to_c_str(byte *S)
@@ -86,6 +93,7 @@ void sioPrinter::initPDF(File *f)
 
 void sioPrinter::formFeed()
 {
+  //todo : spit out blank lines to fill up page
   pdf_xref();
 }
 
@@ -94,36 +102,36 @@ void sioPrinter::sio_write()
 {
   byte ck;
   SIO_UART.readBytes(buffer, 40);
+#ifdef DEBUG_S
   for (int z = 0; z < 40; z++)
   {
     BUG_UART.print(buffer[z], DEC);
+    BUG_UART.print(" ");
   }
   BUG_UART.println();
+#endif
   ck = SIO_UART.read(); // Read checksum
   //delayMicroseconds(350);
   SIO_UART.write('A'); // Write ACK
 
   if (ck == sio_checksum(buffer, 40))
   {
-    delayMicroseconds(DELAY_T5);
-    SIO_UART.write('C');
-#ifdef DEBUG_S
     atari_to_c_str(buffer);
     output.append((char *)buffer);
     if (eolFlag)
     {
-      pdf_add_line(output.c_str());
+      pdf_add_line(output);
       output.clear();
     }
-#endif
     pdf_lineCounter++;
     if (pdf_lineCounter >= maxLines)
     {
       formFeed();
-      initPDF(nullptr);
+      //initPDF(nullptr);
       // todo: open up a new PDF file
     }
-
+    delayMicroseconds(DELAY_T5);
+    SIO_UART.write('C');
     yield();
   }
 }

--- a/platformio/FujiNet/lib/sio/printer.cpp
+++ b/platformio/FujiNet/lib/sio/printer.cpp
@@ -51,18 +51,28 @@ void sioPrinter::pdf_xref()
 }
 void sioPrinter::pdf_add_line(std::string L)
 {
-  int le=L.length();
+  std::string newL;
+  int le = L.length();
+  for (int i = 0; i < le; i++)
+  {
+    if (L[i] >= 32)
+    {
+      newL.append(L,i,1);
+      if (L[i]==92) {newL.append(L,i,1);}
+    }
+  }
+  le = newL.length();
   // to do: handle odd characters for fprintf, e.g., %,'," etc.
   pdf_objCtr++;
   objLocations[pdf_objCtr] = objLocations[pdf_objCtr - 1] + pdf_offset;
   pdf_offset = _file->printf("%d 0 obj <</Length %d>> stream\n", pdf_objCtr, 30 + le);
   int xcoord = pageHeight - lineHeight + bottomMargin - pdf_lineCounter * lineHeight;
   //this string right here vvvvvv is 30 chars long plus the length of the payload
-  pdf_offset += _file->printf("BT /F1 %2d Tf %2d %3d Td (",fontSize, leftMargin, xcoord);
+  pdf_offset += _file->printf("BT /F1 %2d Tf %2d %3d Td (", fontSize, leftMargin, xcoord);
   pdf_offset += le;
-  for (int i=0;i<le;i++)
+  for (int i = 0; i < le; i++)
   {
-    _file->write((byte)L[i]);
+    _file->write((byte)newL[i]);
   }
   pdf_offset += _file->printf(")Tj ET\n");
   pdf_offset += _file->printf("endstream endobj\n");
@@ -95,7 +105,7 @@ void sioPrinter::initPDF(File *f)
 void sioPrinter::formFeed()
 {
   //todo : spit out blank lines to fill up page
-/*   while (pdf_lineCounter < maxLines)
+  /*   while (pdf_lineCounter < maxLines)
   {
     pdf_add_line("");
   } */
@@ -123,13 +133,13 @@ void sioPrinter::sio_write()
   {
     if (pdf_lineCounter < maxLines)
     {
-    atari_to_c_str(buffer);
-    output.append((char *)buffer);
-    if (eolFlag)
-    {
-      pdf_add_line(output);
-      output.clear();
-    }
+      atari_to_c_str(buffer);
+      output.append((char *)buffer);
+      if (eolFlag)
+      {
+        pdf_add_line(output);
+        output.clear();
+      }
     }
     // if (pdf_lineCounter >= maxLines)
     // {

--- a/platformio/FujiNet/lib/sio/printer.cpp
+++ b/platformio/FujiNet/lib/sio/printer.cpp
@@ -66,6 +66,7 @@ void sioPrinter::pdf_add_line(std::string L)
   }
   pdf_offset += _file->printf(")Tj ET\n");
   pdf_offset += _file->printf("endstream endobj\n");
+  pdf_lineCounter++;
 }
 void sioPrinter::atari_to_c_str(byte *S)
 {
@@ -94,6 +95,10 @@ void sioPrinter::initPDF(File *f)
 void sioPrinter::formFeed()
 {
   //todo : spit out blank lines to fill up page
+/*   while (pdf_lineCounter < maxLines)
+  {
+    pdf_add_line("");
+  } */
   pdf_xref();
 }
 
@@ -116,6 +121,8 @@ void sioPrinter::sio_write()
 
   if (ck == sio_checksum(buffer, 40))
   {
+    if (pdf_lineCounter < maxLines)
+    {
     atari_to_c_str(buffer);
     output.append((char *)buffer);
     if (eolFlag)
@@ -123,13 +130,13 @@ void sioPrinter::sio_write()
       pdf_add_line(output);
       output.clear();
     }
-    pdf_lineCounter++;
-    if (pdf_lineCounter >= maxLines)
-    {
-      formFeed();
-      //initPDF(nullptr);
-      // todo: open up a new PDF file
     }
+    // if (pdf_lineCounter >= maxLines)
+    // {
+    //   formFeed();
+    //   //initPDF(nullptr);
+    //   // todo: open up a new PDF file
+    // }
     delayMicroseconds(DELAY_T5);
     SIO_UART.write('C');
     yield();

--- a/platformio/FujiNet/lib/sio/printer.h
+++ b/platformio/FujiNet/lib/sio/printer.h
@@ -20,12 +20,12 @@ private:
 
     int pageWidth = 612;
     int pageHeight = 792;
-    int leftMargin = 66;
+    int leftMargin = 18;
     int bottomMargin = 2;
     int maxLines = 66;
     int maxCols = 80;
     int lineHeight = 12;
-    int fontSize = 10;
+    int fontSize = 12;
     const char *fontName = "Courier";
     int pdf_lineCounter = 0;
     int pdf_offset = 0;             // used to store location offset to next object

--- a/platformio/FujiNet/lib/sio/printer.h
+++ b/platformio/FujiNet/lib/sio/printer.h
@@ -35,7 +35,7 @@ private:
     
     void pdf_header();
     void pdf_xref();
-    void pdf_add_line(const char *L);
+    void pdf_add_line(std::string L);
     void atari_to_c_str(byte *S);
     std::string output;
     int j;

--- a/platformio/FujiNet/src/main.cpp
+++ b/platformio/FujiNet/src/main.cpp
@@ -38,7 +38,9 @@ void httpService()
   client = server.available();
   if (client)
   {
+#ifdef DEBUG_S
     BUG_UART.println("new client");
+#endif
     // an http request ends with a blank line
     boolean currentLineIsBlank = true;
     while (client.connected())
@@ -46,7 +48,9 @@ void httpService()
       if (client.available())
       {
         char c = client.read();
+        #ifdef DEBUG_S
         BUG_UART.write(c);
+        #endif
         // if you've gotten to the end of the line (received a newline
         // character) and the line is blank, the http request has ended,
         // so you can send a reply
@@ -54,9 +58,9 @@ void httpService()
         {
           // send a standard http response header
           // client.println("HTTP/1.1 200 OK");
-          // client.println("Content-Type: text/html");
+          // client.println("Content-Type: application/pdf");
           // client.println("Connection: close");  // the connection will be closed after completion of the response
-          // client.println("Refresh: 5");  // refresh the page automatically every 5 sec
+          // // client.println("Refresh: 5");  // refresh the page automatically every 5 sec
           // client.println();
           // client.println("<!DOCTYPE HTML>");
           // client.println("<html>");
@@ -75,7 +79,9 @@ void httpService()
             else
             {
               client.write(byte(in));
+              #ifdef DEBUG_S
               BUG_UART.write(byte(in));
+              #endif
             }
           }
           pdff.close();

--- a/platformio/FujiNet/src/main.cpp
+++ b/platformio/FujiNet/src/main.cpp
@@ -66,6 +66,7 @@ void httpService()
           // client.println("<html>");
           // client.println("Hello World!");
           // client.println("</html>");
+
           sioP.formFeed();
           pdff.seek(0);
           bool ok = true;

--- a/platformio/FujiNet/src/main.cpp
+++ b/platformio/FujiNet/src/main.cpp
@@ -23,10 +23,10 @@
 
 //File tnfs;
 sioPrinter sioP;
-File atr[8];
+File atr[2];
 File pdff;
 //File tnfs;
-sioDisk sioD[8];
+sioDisk sioD[2];
 
 WiFiServer server(80);
 WiFiClient client;
@@ -127,7 +127,7 @@ void setup()
   pdff = SPIFFS.open("/pdf.out", "w+");
   sioP.initPDF(&pdff);
 
-  for (int i = 0; i < 8; i++)
+  for (int i = 0; i < 2; i++)
   {
     String fname = String("/file") + String(i) + String(".atr");
 #ifdef DEBUG_S


### PR DESCRIPTION
Add fill lines at page eject. Do not overwrite when page full - ignore instead. Begin new document once old one is sent to browser. Ignore char<32. Add extra \\ so it displays in PDF. 