### PR TITLE
add Bluetooth test

### DIFF
--- a/esp32/tests/SIO2BT/README.md
+++ b/esp32/tests/SIO2BT/README.md
@@ -1,0 +1,13 @@
+# Bluetooth with Fujinet
+
+ESP32 can act as a Bluetooth transceiver.
+It supports Serial Port Profile (SPP) and can run as a master.
+
+SIO devices are emulated by the [SIO2BT Android app](https://play.google.com/store/apps/details?id=org.atari.montezuma.sio2bt&hl=en) or [RespeQt PC software](https://github.com/jzatarski/RespeQt/releases) (Windows/Linux/Mac).
+
+Before connecting to the ESP32, devices have to paired. In Android - go to settings, search for Bluetooth devices and select "ATARI Fujinet". Then start the SIO2BT app, which will let you connect to the ESP32.
+
+Pairing on the PC will result in a virtual serial port beeing created. Select this serial port in RespeQT settings and change handshake to "SIO2BT". Opening the port initiates a Bluetooth connection.
+
+
+You can watch the [video](https://www.youtube.com/watch?v=-43HCN8lWMo) to see it live.

--- a/esp32/tests/SIO2BT/SIO2BT.ino
+++ b/esp32/tests/SIO2BT/SIO2BT.ino
@@ -1,0 +1,26 @@
+//This code is based on the example code from Evandro Copercini - 2018
+
+#include "BluetoothSerial.h"
+
+#if !defined(CONFIG_BT_ENABLED) || !defined(CONFIG_BLUEDROID_ENABLED)
+#error Bluetooth is not enabled! Please run `make menuconfig` to and enable it
+#endif
+
+#define RXD2 16
+#define TXD2 17
+
+BluetoothSerial SerialBT;
+
+void setup() {
+  Serial2.begin(57600, SERIAL_8N1, RXD2, TXD2);
+  SerialBT.begin("ATARI FUJINET");
+}
+
+void loop() {
+  if (Serial2.available()) {
+    SerialBT.write(Serial2.read());
+  }
+  if (SerialBT.available()) {
+    Serial2.write(SerialBT.read());
+  }
+}


### PR DESCRIPTION
Bluetooth with Fujinet

ESP32 can act as a Bluetooth transceiver. It supports Serial Port Profile (SPP) and can run as a master.

SIO devices are emulated by the SIO2BT Android app or RespeQt PC software (Windows/Linux/Mac).

Before connecting to the ESP32, devices have to paired. In Android - go to settings, search for Bluetooth devices and select "ATARI Fujinet". Then start the SIO2BT app, which will let you connect to the ESP32.

Pairing on the PC will result in a virtual serial port beeing created. Select this serial port in RespeQT settings and change handshake to "SIO2BT". Opening the port initiates a Bluetooth connection.