### PR TITLE
flip ack/nak behavior to ensure unimplemented commands immediately nak.

### DIFF
--- a/esp32/tests/multilator-rev2/multilator-rev2.ino
+++ b/esp32/tests/multilator-rev2/multilator-rev2.ino
@@ -1753,7 +1753,7 @@ void loop()
 #endif
       if (sio_valid_device_id())
       {
-        if (/*(cmdFrame.comnd == 0x3F) ||*/ (cmdFrame.comnd == 0x4E) || (cmdFrame.comnd == 0x4F))
+        if (cmdPtr[cmdFrame.comnd]==sio_wait)
         {
           sio_nak();
         }


### PR DESCRIPTION
If this breaks things, feel free to slap me, but it seems to work so far with tests.