### PR TITLE
cleanup SIO for 8266 + adjust serial timeouts + update traces

### DIFF
--- a/esp32/tests/multilator-rev2/multilator-rev2.ino
+++ b/esp32/tests/multilator-rev2/multilator-rev2.ino
@@ -47,11 +47,6 @@
 #define PIN_CMD         21
 #endif
 
-#define DELAY_T0  750
-#define DELAY_T1  650
-#define DELAY_T2  0
-#define DELAY_T3  1000
-#define DELAY_T4  850
 #define DELAY_T5  250
 
 bool hispeed = false;
@@ -60,7 +55,8 @@ int command_frame_counter = 0;
 #define HISPEED_INDEX 0x06
 #define HISPEED_BAUDRATE 68837
 #define STANDARD_BAUDRATE 19200
-#define SERIAL_TIMEOUT 300
+#define SERIAL_TIMEOUT_COMMAND_FRAME 20
+#define SERIAL_TIMEOUT 1000
 
 /**
    A Single command frame, both in structured and unstructured
@@ -274,9 +270,7 @@ bool sio_valid_device_id()
 void sio_nak()
 {
   SIO_UART.write('N');
-#ifdef ESP32
   SIO_UART.flush();
-#endif
 }
 
 /**
@@ -285,9 +279,7 @@ void sio_nak()
 void sio_ack()
 {
   SIO_UART.write('A');
-#ifdef ESP32
   SIO_UART.flush();
-#endif
 }
 
 /**
@@ -317,10 +309,6 @@ void sio_error()
 void sio_to_computer(byte* b, unsigned short len, bool err)
 {
   byte ck = sio_checksum(b, len);
-
-#ifdef ESP8266
-  delayMicroseconds(DELAY_T5);
-#endif
 
   if (err == true)
     sio_error();
@@ -368,10 +356,6 @@ byte sio_to_peripheral(byte* b, unsigned short len)
   for (int i = 0; i < len; i++)
     Debug_printf("%02x ", sector[i]);
   Debug_printf("\nCKSUM: %02x\n\n", ck);
-#endif
-
-#ifdef ESP8266
-  delayMicroseconds(DELAY_T4);
 #endif
 
   if (sio_checksum(b, len) != ck)
@@ -1799,7 +1783,6 @@ void setup()
 
   // Set up serial
   SIO_UART.begin(STANDARD_BAUDRATE);
-  SIO_UART.setTimeout(SERIAL_TIMEOUT);
 #ifdef ESP8266
   SIO_UART.swap();
 #endif
@@ -1844,27 +1827,20 @@ void loop()
     sio_led(true);
     memset(cmdFrame.cmdFrameData, 0, 5); // clear cmd frame.
 
-#ifdef ESP8266
-    delayMicroseconds(DELAY_T0); // computer is waiting for us to notice.
-#endif
-
     // read cmd frame
-    SIO_UART.readBytes(cmdFrame.cmdFrameData, 5);
+    SIO_UART.setTimeout(SERIAL_TIMEOUT_COMMAND_FRAME);
+    int bytesRead = SIO_UART.readBytes(cmdFrame.cmdFrameData, 5);
+    SIO_UART.setTimeout(SERIAL_TIMEOUT);
 #ifdef DEBUG
-    Debug_printf("CF: %02x %02x %02x %02x %02x\n", cmdFrame.devic, cmdFrame.comnd, cmdFrame.aux1, cmdFrame.aux2, cmdFrame.cksum);
+    Debug_printf("CF: %02x %02x %02x %02x %02x read %d bytes\n", cmdFrame.devic, cmdFrame.comnd, cmdFrame.aux1, cmdFrame.aux2, cmdFrame.cksum, bytesRead);
 #endif
 
     byte ck = sio_checksum(cmdFrame.cmdFrameData, 4);
     if (ck == cmdFrame.cksum)
     {
-#ifdef ESP8266
-      delayMicroseconds(DELAY_T1);
-#endif
       // Wait for CMD line to raise again
       while (digitalRead(PIN_CMD) == LOW) yield();
-#ifdef ESP8266
-      delayMicroseconds(DELAY_T2);
-#endif
+
       if (sio_valid_device_id())
       {
         if (cmdPtr[cmdFrame.comnd] == sio_wait)
@@ -1873,16 +1849,8 @@ void loop()
         }
         else
         {
-          if (sio_checksum(cmdFrame.cmdFrameData, 4) == cmdFrame.cksum)
-          {
-            sio_ack();
-#ifdef ESP8266
-            delayMicroseconds(DELAY_T3);
-#endif
-            cmdPtr[cmdFrame.comnd]();
-          }
-          else
-            sio_nak();
+          sio_ack();
+          cmdPtr[cmdFrame.comnd]();
         }
       }
     }
@@ -1915,9 +1883,6 @@ void loop()
   else
   {
     sio_led(false);
-    a = SIO_UART.available();
-    if (a)
-      while (SIO_UART.available())
-        SIO_UART.read(); // dump it.
+    while (SIO_UART.available()) SIO_UART.read(); // dump it.
   }
 }


### PR DESCRIPTION
I have finally tested SIO timing on ESP8266 and removed superfluous sleeps from the code.
While merging my changes to the latest code base I had to resolve conflicts and removed duplicated checking of the command frame checksum.
According SIO spec: if the checksum if not correct, the SIO device should ignore the command (instead of sending NAK).
Regarding High Speed handling:
- $3F is a request about device capabilities and is meant to be send to floppy drives only (for example there is a conflict with $3F command for poll type 1)
- the HIAS's high speed patch and FJC U1MB firmware maintain HS index values for SIO devices 
 (for example: if D1 is accessed first time, its speed capabilities will be requested. The next time it will be accessed with that speed.
  Should D2  be accessed, again $3F is send (with 19200), this time to D2., etc.)
- the device emulating high speed devices have to deal with SIO requests with normal and high speed. 
  That's why it has to be able to switch between different speeds.