### PR TITLE
keep the SIO LED on all the time when doing Bluetooth

### DIFF
--- a/esp32/tests/multilator-rev2/multilator-rev2.ino
+++ b/esp32/tests/multilator-rev2/multilator-rev2.ino
@@ -2025,12 +2025,14 @@ void handle_hardkeys()
           bt_mode = false;
           SerialBT.end();
           SIO_UART.updateBaudRate(STANDARD_BAUDRATE);
+          sio_led(false);
       }
       else
       {
           bt_mode = true;
           SerialBT.begin("ATARI FUJINET");
           SIO_UART.updateBaudRate(BT_BAUDRATE);
+          sio_led(true);
       }
 #endif
     }


### PR DESCRIPTION
My NodeMCU (ESP32) does not have LEDs connected to the pins specified in the sketch.
That's why I couldn't test the commit, but I guess it should work.
I think that the user shall get visual feedback, when the long press is detected.
