### PR TITLE
Made the relocator smarter by allowing the programmer to specify where

### DIFF
--- a/esp32/tests/tcp/atari-cio-relocator/rel.s
+++ b/esp32/tests/tcp/atari-cio-relocator/rel.s
@@ -6,8 +6,12 @@
 ;;; _reloc_begin & _reloc_end mark the region of 
 ;;; memory to be moved.
 ;;;
+;;; _reloc_code_begin is the beginning of the
+;;; code to be scanned for address fixups.
+;;;
 
 	.export _reloc_begin
+	.export _reloc_code_begin
 	.export _function1
 	.export _function2
 	.export _function3
@@ -15,16 +19,52 @@
 	
 	.code
 
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; _reloc_begin is where the relocator starts
+;;; working from.
+;;; 
 _reloc_begin:
-	
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; public function table.  this table needs to
+;;; reside at the beginning of the region to be
+;;; remapped.  following the function table the
+;;; programmer is free to declare data elements
+;;; used by the public/private functions.
+;;;
+;;; the format is as follows:
+;;;
+;;;    # of functions (byte)
+;;;    function1 (word)
+;;;    function2 (word)
+;;;    functionN (word)
+;;; 
 _functab:
+	.byte 3			; number of public functions exposed via USR()
 	.word _function1
 	.word _function2
 	.word _function3
 
+_data_table:
+	.byte 1			; data to be returned to basic USR()
+	.byte 2			; ...ditto for function 2
+	.byte 4			; ...ditto for function 3
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; _reloc_code_begin is where the relocator scans
+;;; for instruction remapping - right now it only
+;;; handles 3 byte instructions.
+;;; 
+_reloc_code_begin:
+	
 _function1:
 	pla			; pull length byte
-	lda	#$01
+	ldy	#$00
+	lda	_data_table,y
 	sta	$d4
 	lda	#$00
 	sta	$d4+1
@@ -32,7 +72,8 @@ _function1:
 	
 _function2:
 	pla			; pull length byte
-	lda	#$02
+	ldy	#$01
+	lda	_data_table,y
 	sta	$d4
 	lda	#$00
 	sta	$d4+1
@@ -40,21 +81,26 @@ _function2:
 	
 _function3:
 	pla			; pull length byte
-	jmp	_return4instead
-	lda	#$03
-	sta	$d4
-	lda	#$00
-_return4instead:
-	jsr	privatefunction
+	jsr	privatefunction	; call private function...
 	rts
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; declare a private function used by code that is
+;;; relocated.
+;;; 
 privatefunction:
-	lda	#$04
+	ldy	#$02
+	lda	_data_table,y
 	sta	$d4
 	lda	#$00
 	sta	$d4+1
 	rts
-	
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; _reloc_end is where the relocator stops working
+;;; 
 _reloc_end:
 
 	.end


### PR DESCRIPTION
Code and data reside within the region to be remapped.  We really don't
want the remapper ruining data within the segment do we?  Nope.

The example assembly file shows how to write assembly that works with
the remapper.