### PR TITLE
platformio/siodisk: do not process cmds for null disk

### DIFF
--- a/platformio/FujiNet/lib/sio/disk.cpp
+++ b/platformio/FujiNet/lib/sio/disk.cpp
@@ -356,6 +356,9 @@ void sioDisk::sio_high_speed()
 // Process command
 void sioDisk::sio_process()
 {
+  if (_file == nullptr) // if there is no disk mounted, just return cuz there's nothing to do
+    return;
+
   switch (cmdFrame.comnd)
   {
   case 'R':
@@ -419,7 +422,8 @@ void sioDisk::mount(File *f)
   _file = f;
 
 #ifdef DEBUG
-  Debug_println("mounting ATR to Disk");
+  Debug_print("mounting ATR to Disk: ");
+  Debug_println(f->name());
   Debug_printf("num_para: %d\n", num_para);
   Debug_printf("sectorSize: %d\n", newss);
   Debug_printf("num_sectors: %d\n", num_sectors);

--- a/platformio/FujiNet/src/main.cpp
+++ b/platformio/FujiNet/src/main.cpp
@@ -179,16 +179,9 @@ void setup()
   SPIFFS.begin();
 
   theFuji.begin();
-#ifdef DEBUG_S
-  BUG_UART.println("/autorun.atr for FujiNet device");
-#endif
 
-  SPIFFS.begin();
   //atr[0] = SPIFFS.open("/file1.atr", "r+");
   //sioD[0].mount(&atr[0]);
-#ifdef DEBUG_S
-  BUG_UART.println("/file1.atr");
-#endif
   for (int i = 0; i < 8; i++)
   {
     SIO.addDevice(&sioD[i], 0x31 + i);
@@ -277,7 +270,7 @@ void setup()
 #endif
 
   SIO.setup();
-#ifdef DEBUG
+#if defined(DEBUG) && defined(ESP32)
   Debug_print("SIO Voltage: ");
   Debug_println(SIO.sio_volts());
 #endif


### PR DESCRIPTION
platformio/siodisk: do not process commands for a drive whose file pointer is null (disk not mounted)