### PR TITLE
add SIO2BT mode

### DIFF
--- a/platformio/FujiNet/lib/hardware/bluetooth.cpp
+++ b/platformio/FujiNet/lib/hardware/bluetooth.cpp
@@ -1,0 +1,54 @@
+#include "bluetooth.h"
+#include "sio.h"
+#include "disk.h"
+#include "BluetoothSerial.h"
+
+BluetoothSerial SerialBT;
+
+void BluetoothManager::setup()
+{
+  SerialBT.begin(BT_NAME);
+}
+
+void BluetoothManager::start()
+{
+  BUG_UART.println("START SIO2BT");
+  mActive = true;
+  mPrevBaudrate = SIO.getBaudrate();
+  SIO.setBaudrate(mBTBaudrate);
+  SIO.sio_led(true);
+}
+
+void BluetoothManager::stop()
+{
+  BUG_UART.println("STOP SIO2BT");
+  mActive = false;
+  SIO.setBaudrate(mPrevBaudrate);
+  SIO.sio_led(false);
+}
+
+eBTBaudrate BluetoothManager::toggleBaudrate()
+{
+  SIO.sio_led(false);
+  if(mBTBaudrate == eBTBaudrate::BT_STANDARD_BAUDRATE)
+  {
+    mBTBaudrate = eBTBaudrate::BT_HISPEED_BAUDRATE;
+  }
+  else
+  {
+    mBTBaudrate = eBTBaudrate::BT_STANDARD_BAUDRATE;
+  }
+  SIO.setBaudrate(mBTBaudrate);
+  SIO.sio_led(true);
+  return mBTBaudrate;
+}
+
+void BluetoothManager::service()
+{
+    if (SIO_UART.available()) {
+      SerialBT.write(SIO_UART.read());
+    }
+    if (SerialBT.available()) {
+      SIO_UART.write(SerialBT.read());
+    }
+}

--- a/platformio/FujiNet/lib/hardware/bluetooth.h
+++ b/platformio/FujiNet/lib/hardware/bluetooth.h
@@ -1,0 +1,35 @@
+#ifndef BLUETOOTH_H
+#define BLUETOOTH_H
+
+#include <Arduino.h>
+#include "debug.h"
+
+#define BT_NAME "ATARI FUJINET"
+
+enum eBTBaudrate
+{
+    BT_STANDARD_BAUDRATE = 19200,
+    BT_HISPEED_BAUDRATE = 57600
+};
+
+class BluetoothManager
+{
+public:
+    void setup();
+    bool isActive();
+    void start();
+    void stop();
+    eBTBaudrate toggleBaudrate();
+    void service();
+private:
+    eBTBaudrate mBTBaudrate = eBTBaudrate::BT_STANDARD_BAUDRATE;
+    int mPrevBaudrate = eBTBaudrate::BT_STANDARD_BAUDRATE;
+    bool mActive = false;
+};
+
+inline bool BluetoothManager::isActive()
+{
+    return mActive;
+}
+
+#endif // guard

--- a/platformio/FujiNet/lib/sio/disk.cpp
+++ b/platformio/FujiNet/lib/sio/disk.cpp
@@ -1,6 +1,5 @@
 #include "disk.h"
 
-bool hispeed = false;
 int command_frame_counter = 0;
 
 /**

--- a/platformio/FujiNet/lib/sio/disk.h
+++ b/platformio/FujiNet/lib/sio/disk.h
@@ -5,7 +5,6 @@
 #include "sio.h"
 #include <FS.h>
 
-extern bool hispeed;
 extern int command_frame_counter;
 #define COMMAND_FRAME_SPEED_CHANGE_THRESHOLD 2
 #define HISPEED_INDEX 0x05

--- a/platformio/FujiNet/lib/sio/sio.cpp
+++ b/platformio/FujiNet/lib/sio/sio.cpp
@@ -308,21 +308,13 @@ void sioBus::service()
              if (COMMAND_FRAME_SPEED_CHANGE_THRESHOLD == command_frame_counter)
              {
               command_frame_counter = 0;
-              if (hispeed)
+              if (sioBaud == HISPEED_BAUDRATE)
               {
-      #ifdef DEBUG
-                Debug_printf("Switching to %d baud...\n", STANDARD_BAUDRATE);
-      #endif
-                SIO_UART.updateBaudRate(STANDARD_BAUDRATE);
-                hispeed = false;
+                setBaudrate(STANDARD_BAUDRATE);
               }
               else
               {
-      #ifdef DEBUG
-                Debug_printf("Switching to %d baud...\n", HISPEED_BAUDRATE);
-      #endif
-                SIO_UART.updateBaudRate(HISPEED_BAUDRATE);
-                hispeed = true;
+                setBaudrate(HISPEED_BAUDRATE);
               }
             }
     }
@@ -405,6 +397,20 @@ int sioBus::numDevices()
 sioDevice *sioBus::device(int i)
 {
   return daisyChain.get(i);
+}
+
+int sioBus::getBaudrate()
+{
+  return sioBaud;
+}
+
+void sioBus::setBaudrate(int baudrate)
+{
+#ifdef DEBUG
+  sioBaud = baudrate;
+  Debug_printf("Switching to %d baud...\n", sioBaud);
+  SIO_UART.updateBaudRate(sioBaud);
+#endif
 }
 
 /**

--- a/platformio/FujiNet/lib/sio/sio.h
+++ b/platformio/FujiNet/lib/sio/sio.h
@@ -96,17 +96,19 @@ private:
    sioModem *modemDev = nullptr;
    sioFuji *fujiDev = nullptr;
 
-   void sio_led(bool onOff);
+   int sioBaud = 19200; // SIO Baud rate
 
 public:
    int numDevices();
-   long sioBaud = 19200; // SIO Baud rate
 
    void setup();
    void service();
    void addDevice(sioDevice *p, int N);
    bool remDevice(sioDevice *p);
    sioDevice *device(int i);
+   int getBaudrate();
+   void setBaudrate(int baudrate);
+   void sio_led(bool onOff);
 #ifdef ESP32
    int sio_volts();
 #endif

--- a/platformio/FujiNet/platformio.ini
+++ b/platformio/FujiNet/platformio.ini
@@ -32,6 +32,7 @@ build_flags =
     -D DEBUG_S
     -D BUG_UART=Serial
     -D DEBUG_SPEED=921600
+    -D BLUETOOTH_SUPPORT
 upload_port = COM14 ;COM3
 upload_speed = 921600
 monitor_port = COM14 ;COM3

--- a/platformio/FujiNet/src/main.cpp
+++ b/platformio/FujiNet/src/main.cpp
@@ -44,6 +44,10 @@ hacked in a special case for SD - set host as "SD" in the Atari config program
 #include "keys.h"
 #endif
 
+#ifdef BLUETOOTH_SUPPORT
+#include "bluetooth.h"
+#endif
+
 //#define TNFS_SERVER "192.168.1.12"
 //#define TNFS_PORT 16384
 
@@ -63,6 +67,10 @@ WiFiClient wifiDebugClient;
 #endif
 
 KeyManager keyMgr;
+
+#ifdef BLUETOOTH_SUPPORT
+BluetoothManager btMgr;
+#endif
 
 void httpService()
 {
@@ -283,6 +291,10 @@ void setup()
   Debug_println(SIO.sio_volts());
 #endif
 
+#ifdef BLUETOOTH_SUPPORT
+  btMgr.setup();
+#endif
+
   void sio_flush();
 }
 
@@ -306,14 +318,39 @@ void loop()
   {
     case eKeyStatus::LONG_PRESSED:
       BUG_UART.println("LONG PRESS");
+#ifdef BLUETOOTH_SUPPORT
+      if(btMgr.isActive())
+      {
+        btMgr.stop();
+      }
+      else
+      {
+        btMgr.start();
+      }
+#endif
       break;
     case eKeyStatus::SHORT_PRESSED:
       BUG_UART.println("SHORT PRESS");
+#ifdef BLUETOOTH_SUPPORT
+      if(btMgr.isActive())
+      {
+        btMgr.toggleBaudrate();
+      }
+#endif
       break;
     default:
       break;
   }
 
-  SIO.service();
-  httpService();
+#ifdef BLUETOOTH_SUPPORT
+  if(btMgr.isActive())
+  {
+    btMgr.service();
+  }
+  else
+#endif
+  {
+    SIO.service();
+    httpService();
+  }
 }


### PR DESCRIPTION
Due to a bug in the Arduino libraries:
https://github.com/espressif/arduino-esp32/issues/2718
I introduced a workaround to let Bluetooth be available all the time.
With the long press we toggle between Fujinet and SIO2BT mode.
