### PR TITLE
correct short key press logic

### DIFF
--- a/platformio/FujiNet/src/main.cpp
+++ b/platformio/FujiNet/src/main.cpp
@@ -346,9 +346,11 @@ void loop()
       {
         btMgr.toggleBaudrate();
       }
-#else
-      theFuji.image_rotate();
+      else
 #endif
+      {
+        theFuji.image_rotate();
+      }
       break;
     default:
       break;


### PR DESCRIPTION
A small correction, so the short key presses work well with or without BLUETOOTH_SUPPORT defined