### PR TITLE
append '/' to directory names sent to CONFIG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 platformio/tnfs test/include/ssid.h
 platformio/FujiNet/platformio.ini
+*.ini

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 platformio/tnfs test/include/ssid.h
+platformio/FujiNet/platformio.ini

--- a/platformio/FujiNet/lib/TNFSlib/tnfs_imp.cpp
+++ b/platformio/FujiNet/lib/TNFSlib/tnfs_imp.cpp
@@ -336,7 +336,9 @@ FileImplPtr TNFSFileImpl::openNextFile(const char *mode)
     // return fs->open(path, "r");
     tnfsStat_t fstats = tnfs_stat(fs, path); // get stats on next file
     // create file pointer without opening file - set FID=-2
-    if (fstats.isDir)
+   // TODO: remove this append / logic to make work like rest of FS
+   // append / is now in sioFuji::sio_tnfs_read_directory_entry() 
+   if (fstats.isDir)
     {
       std::string P = std::string(path);
       P.push_back('/');

--- a/platformio/FujiNet/lib/TNFSlib/tnfs_imp.cpp
+++ b/platformio/FujiNet/lib/TNFSlib/tnfs_imp.cpp
@@ -338,12 +338,12 @@ FileImplPtr TNFSFileImpl::openNextFile(const char *mode)
     // create file pointer without opening file - set FID=-2
    // TODO: remove this append / logic to make work like rest of FS
    // append / is now in sioFuji::sio_tnfs_read_directory_entry() 
-   if (fstats.isDir)
-    {
-      std::string P = std::string(path);
-      P.push_back('/');
-      strcpy(path, P.c_str());
-    }
+  //  if (fstats.isDir)
+  //   {
+  //     std::string P = std::string(path);
+  //     P.push_back('/');
+  //     strcpy(path, P.c_str());
+  //   }
     return std::make_shared<TNFSFileImpl>(fs, -2, path, fstats);
   }
   return nullptr;

--- a/platformio/FujiNet/lib/sio/fuji.cpp
+++ b/platformio/FujiNet/lib/sio/fuji.cpp
@@ -17,7 +17,7 @@ sioNetwork sioN[8];
 
 void sioFuji::sio_status()
 {
-    char ret[4]={0,0,0,0};
+    char ret[4] = {0, 0, 0, 0};
 
     sio_to_computer((byte *)ret, 4, false);
     return;
@@ -197,14 +197,14 @@ int sioFuji::image_rotate()
     {
         n++;
     }
-    
+
     if (n > 1)
     {
         n--;
         temp = sioD[n].file();
         for (int i = n; i > 0; i--)
         {
-            sioD[i].mount(sioD[i-1].file());
+            sioD[i].mount(sioD[i - 1].file());
         }
         sioD[0].mount(temp);
     }
@@ -227,8 +227,8 @@ void sioFuji::sio_tnfs_open_directory()
     }
 
 #ifdef DEBUG
-    Debug_print("FujiNet is opening / for reading.");
-//Debug_println(current_entry);
+    Debug_print("FujiNet is opening directory: ");
+    Debug_println(current_entry);
 #endif
 
     //     if (current_entry[0] != '/')
@@ -242,12 +242,11 @@ void sioFuji::sio_tnfs_open_directory()
     //     }
 
     // Remove trailing slash
-    if ((strlen(current_entry)>1) && (current_entry[strlen(current_entry)-1]=='/'))
-        current_entry[strlen(current_entry)-1]=0x00;
+    if ((strlen(current_entry) > 1) && (current_entry[strlen(current_entry) - 1] == '/'))
+        current_entry[strlen(current_entry) - 1] = 0x00;
 
     //dir[hostSlot] = fileSystems[hostSlot]->open("/", "r");
     dir[hostSlot] = fileSystems[hostSlot]->open(current_entry, "r");
-    //dir[hostSlot] = TNFS[hostSlot].open(current_entry, "r");
 
     if (dir[hostSlot])
         sio_complete();
@@ -271,6 +270,15 @@ void sioFuji::sio_tnfs_read_directory_entry()
     else
     {
         strcpy(current_entry, f.name());
+        if (f.isDirectory())
+        {
+            int a = strlen(current_entry);
+            if (current_entry[--a] != '/')
+            {
+                current_entry[a++] = '/';
+                current_entry[a] = '\0';
+            }
+        }
     }
     sio_to_computer((byte *)&current_entry, len, false);
 }
@@ -373,7 +381,7 @@ void sioFuji::sio_get_adapter_config()
     adapterConfig.dnsIP[3] = WiFi.dnsIP()[3];
 
     WiFi.macAddress(adapterConfig.macAddress);
-    strncpy((char *)adapterConfig.bssid,(const char *)WiFi.BSSID(),6);
+    strncpy((char *)adapterConfig.bssid, (const char *)WiFi.BSSID(), 6);
 
     sio_to_computer(adapterConfig.rawData, sizeof(adapterConfig.rawData), false);
 }

--- a/platformio/FujiNet/lib/sio/fuji.cpp
+++ b/platformio/FujiNet/lib/sio/fuji.cpp
@@ -275,8 +275,8 @@ void sioFuji::sio_tnfs_read_directory_entry()
             int a = strlen(current_entry);
             if (current_entry[--a] != '/')
             {
-                current_entry[a++] = '/';
-                current_entry[a] = '\0';
+                current_entry[++a] = '/';
+                current_entry[++a] = '\0';
             }
         }
     }

--- a/platformio/FujiNet/platformio.ini
+++ b/platformio/FujiNet/platformio.ini
@@ -33,9 +33,9 @@ build_flags =
     -D BUG_UART=Serial
     -D DEBUG_SPEED=921600
 ;    -D BLUETOOTH_SUPPORT
-upload_port = COM3 ;COM3
+upload_port = COM14 ;COM3
 upload_speed = 921600
-monitor_port = COM3 ;COM3
+monitor_port = COM14 ;COM3
 monitor_speed = 921600
-;board_build.partitions = partitions_fujinet.csv
+board_build.partitions = partitions_fujinet.csv
 board_build.f_cpu = 240000000L


### PR DESCRIPTION
address issue #172 by adding a '/' to end of directory names sent to CONFIG for display and directory traversal by the user.