### PR TITLE
change flash partitions to bring more space for 4MB hardware

### DIFF
--- a/platformio/FujiNet/fujinet_partitions_16MB.csv
+++ b/platformio/FujiNet/fujinet_partitions_16MB.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x7B0000,
+app1,     app,  ota_1,   0x7C0000,0x7B0000,
+spiffs,   data, spiffs,  0xF70000,0x90000,

--- a/platformio/FujiNet/fujinet_partitions_4MB.csv
+++ b/platformio/FujiNet/fujinet_partitions_4MB.csv
@@ -1,6 +1,5 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 nvs,      data, nvs,     0x9000,  0x5000,
 otadata,  data, ota,     0xe000,  0x2000,
-app0,     app,  ota_0,   0x10000, 0x1B0000,
-app1,     app,  ota_1,   0x1C0000,0x1B0000,
+app0,     app,  ota_0,   0x10000, 0x360000,
 spiffs,   data, spiffs,  0x370000,0x90000,

--- a/platformio/FujiNet/platformio.ini
+++ b/platformio/FujiNet/platformio.ini
@@ -31,10 +31,10 @@ build_flags =
     -D DEBUG_S
     -D BUG_UART=Serial
     -D DEBUG_SPEED=921600
-;    -D BLUETOOTH_SUPPORT
+    -D BLUETOOTH_SUPPORT
 upload_port = COM5 ;COM3
 upload_speed = 921600
 monitor_port = COM5 ;COM3
 monitor_speed = 921600
-board_build.partitions = fujinet_partitions.csv
+board_build.partitions = fujinet_partitions_4MB.csv
 ;lib_ldf_mode = deep+


### PR DESCRIPTION
Introduced 2 partition configurations:
- 4MB (without OTA)
- 16MB (with OTA)
Both configurations support 576kB spiffs.

Changes in paltformio.ini :
- it uses now fujinet_partitions_4MB.csv
- Bluetooth is enabled