### PR TITLE
Bluetooth rework

### DIFF
--- a/platformio/FujiNet/lib/hardware/bluetooth.cpp
+++ b/platformio/FujiNet/lib/hardware/bluetooth.cpp
@@ -7,18 +7,13 @@
 
 BluetoothSerial SerialBT;
 
-void BluetoothManager::setup()
-{
-  SerialBT.begin(BT_NAME);
-}
-
 void BluetoothManager::start()
 {
 #ifdef DEBUG
   Debug_println("START SIO2BT");
 #endif
+  SerialBT.begin(BT_NAME);
   mActive = true;
-  mPrevBaudrate = SIO.getBaudrate();
   SIO.setBaudrate(mBTBaudrate);
 }
 
@@ -28,7 +23,8 @@ void BluetoothManager::stop()
   BUG_UART.println("STOP SIO2BT");
 #endif
   mActive = false;
-  SIO.setBaudrate(mPrevBaudrate);
+  SIO.setBaudrate(eBTBaudrate::BT_STANDARD_BAUDRATE);
+  SerialBT.end();
 }
 
 eBTBaudrate BluetoothManager::toggleBaudrate()

--- a/platformio/FujiNet/lib/hardware/bluetooth.h
+++ b/platformio/FujiNet/lib/hardware/bluetooth.h
@@ -12,7 +12,6 @@ enum eBTBaudrate
 class BluetoothManager
 {
 public:
-    void setup();
     bool isActive();
     void start();
     void stop();
@@ -20,7 +19,6 @@ public:
     void service();
 private:
     eBTBaudrate mBTBaudrate = eBTBaudrate::BT_STANDARD_BAUDRATE;
-    int mPrevBaudrate = eBTBaudrate::BT_STANDARD_BAUDRATE;
     bool mActive = false;
 };
 

--- a/platformio/FujiNet/platformio.ini
+++ b/platformio/FujiNet/platformio.ini
@@ -33,7 +33,7 @@ build_flags =
     -D DEBUG_S
     -D BUG_UART=Serial
     -D DEBUG_SPEED=921600
-    ;-D BLUETOOTH_SUPPORT
+    -D BLUETOOTH_SUPPORT
 upload_port = COM3 ;COM3
 upload_speed = 921600
 monitor_port = COM3 ;COM3

--- a/platformio/FujiNet/src/main.cpp
+++ b/platformio/FujiNet/src/main.cpp
@@ -177,10 +177,6 @@ void setup()
   Debug_println(SIO.sio_volts());
 #endif
 
-#ifdef BLUETOOTH_SUPPORT
-  btMgr.setup();
-#endif
-
   keyMgr.setup();
   ledMgr.setup();
 

--- a/platformio/FujiNet/src/main.cpp
+++ b/platformio/FujiNet/src/main.cpp
@@ -238,8 +238,8 @@ void loop()
     }
     else
     {
-      btMgr.start();
       ledMgr.set(eLed::LED_SIO, true); // SIO LED always ON in Bluetooth mode
+      btMgr.start();
     }
 #endif
     break;


### PR DESCRIPTION
Now Bluetooth is started only on demand (long key pressed), so there is no shortage of resources needed for other components.

Drawback:
BT restart (3 x long key press) causes a crash and reboot, so it is recommended to apply a fix to the file:
`esp32-hal-bt.c`
located at:
`path_to_user_data\.platformio\packages\framework-arduinoespressif32\cores\esp32`
as described here:
https://github.com/espressif/arduino-esp32/issues/2718#issuecomment-552213656

This is the corrected version of the btStop() method:
```
bool btStop(){
    if(esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_IDLE){
        return true;
    }
    if(esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED){
        if (esp_bt_controller_disable()) {
            log_e("BT Disable failed");
            return false;
        }
        while(esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED);
    }
    if(esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_INITED){
		log_i("inited");
		if (esp_bt_controller_deinit()) {
			log_e("BT deinit failed");
			return false;
		}
		while (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_INITED);
        return true;
    }
    log_e("BT Stop failed");
    return false;
}
```
