### PR TITLE
change fnconfig.ini read behavior to favor SD

### DIFF
--- a/platformio/FujiNet/lib/TNFSlib/tnfslib.cpp
+++ b/platformio/FujiNet/lib/TNFSlib/tnfslib.cpp
@@ -218,11 +218,9 @@ int tnfs_open(tnfsMountInfo *m_info, const char *filepath, uint16_t open_mode, u
     tnfsPacket packet;
     packet.command = TNFS_CMD_OPEN;
 
-    // Set the open mode (does not appear to be little-endian)
     packet.payload[0] = TNFS_LOBYTE_FROM_UINT16(open_mode);
     packet.payload[1] = TNFS_HIBYTE_FROM_UINT16(open_mode);
 
-    // Set create permissions (does not appear to be little-endian)
     packet.payload[2] = TNFS_LOBYTE_FROM_UINT16(create_perms);
     packet.payload[3] = TNFS_HIBYTE_FROM_UINT16(create_perms);
 

--- a/platformio/FujiNet/lib/TNFSlib/tnfslib.h
+++ b/platformio/FujiNet/lib/TNFSlib/tnfslib.h
@@ -131,6 +131,7 @@ struct tnfsStat
 // Returns a uint32 value from a pointer to four bytes in little-ending order
 #define TNFS_UINT32_FROM_LOHI_BYTEPTR(bytep) ( (uint32_t)(*(bytep+3)) << 24 | (uint32_t)(*(bytep+2)) << 16 | (uint32_t)(*(bytep+1)) << 8 | (*(bytep+0)))
 
+// Takes UINT32 value and pushes it into 4 consecutive bytes in little-endian order
 #define TNFS_UINT32_TO_LOHI_BYTEPTR(value, bytep) { \
     (bytep)[0] = value & 0xFFUL; \
     (bytep)[1] = value >> 8 & 0xFFUL; \


### PR DESCRIPTION
Previous behavior: look for fnconfig.ini on SPIFFS and only make a copy from SD if none found.
New behavior: always copy fnconfig.ini from SD if found, then try to read what we have on SPIFFS.