### PR TITLE
global sioPrinter relaced with dynamically-allocated object

### DIFF
--- a/platformio/FujiNet/lib/FileSystem/fnFS.cpp
+++ b/platformio/FujiNet/lib/FileSystem/fnFS.cpp
@@ -38,3 +38,18 @@ long FileSystem::filesize(FILE *f)
     fseek(f, curr, SEEK_SET);
     return end;
 }
+
+const char * FileSystem::type_to_string(fsType type)
+{
+    switch(type)
+    {
+        case FSTYPE_SPIFFS:
+            return "FS_SPIFFS";
+        case FSTYPE_SDFAT:
+            return "FS_SDFAT";
+        case FSTYPE_TNFS:
+            return "FS_TNFS";
+        default:
+            return "UNKNOWN FS TYPE";
+    }
+}

--- a/platformio/FujiNet/lib/FileSystem/fnFS.h
+++ b/platformio/FujiNet/lib/FileSystem/fnFS.h
@@ -14,11 +14,12 @@
 
 enum fsType
 {
-    FSTYPE_SPIFFS,
+    FSTYPE_SPIFFS = 0,
     FSTYPE_SDFAT,
     FSTYPE_TNFS,
     FSTYPE_COUNT
 };
+
 
 struct fsdir_entry
 {
@@ -48,6 +49,9 @@ public:
     virtual const char * basepath() { return _basepath; };
     
     virtual fsType type()=0;
+    virtual const char *typestring()=0;
+
+    static const char *type_to_string(fsType type);
 
     static long filesize(FILE *);
 

--- a/platformio/FujiNet/lib/FileSystem/fnFsSD.h
+++ b/platformio/FujiNet/lib/FileSystem/fnFsSD.h
@@ -13,6 +13,7 @@ public:
     virtual bool is_global() override { return true; };
 
     fsType type() override { return FSTYPE_SDFAT; };
+    const char * typestring() override { return type_to_string(FSTYPE_SDFAT); };
 
     FILE * file_open(const char* path, const char* mode = FILE_READ) override;
 

--- a/platformio/FujiNet/lib/FileSystem/fnFsSPIF.h
+++ b/platformio/FujiNet/lib/FileSystem/fnFsSPIF.h
@@ -11,6 +11,8 @@ public:
     bool start();
     
     fsType type() override { return FSTYPE_SPIFFS; };
+    const char * typestring() override { return type_to_string(FSTYPE_SPIFFS); };
+
     virtual bool is_global() override { return true; };    
 
     FILE * file_open(const char* path, const char* mode = FILE_READ) override;

--- a/platformio/FujiNet/lib/FileSystem/fnFsTNFS.h
+++ b/platformio/FujiNet/lib/FileSystem/fnFsTNFS.h
@@ -19,6 +19,7 @@ public:
     bool start(const char *host, uint16_t port=TNFS_DEFAULT_PORT, const char * mountpath=nullptr, const char * userid=nullptr, const char * password=nullptr);
 
     fsType type() override { return FSTYPE_TNFS; };
+    const char * typestring() override { return type_to_string(FSTYPE_TNFS); };
 
     FILE * file_open(const char* path, const char* mode = FILE_READ) override;
 

--- a/platformio/FujiNet/lib/http/httpService.cpp
+++ b/platformio/FujiNet/lib/http/httpService.cpp
@@ -252,7 +252,10 @@ esp_err_t fnHttpService::get_handler_print(httpd_req_t *req)
 #endif
 
     time_t now = fnSystem.millis();
-    if (now - sioP.lastPrintTime() < PRINTER_BUSY_TIME)
+    // Get a pointer to the current (only) printer
+    sioPrinter *printer = (sioPrinter *)SIO.deviceById(SIO_DEVICEID_PRINTER);
+
+    if (now - printer->lastPrintTime() < PRINTER_BUSY_TIME)
     {
         _fnwserr err = fnwserr_post_fail;
         return_http_error(req, err);
@@ -260,7 +263,7 @@ esp_err_t fnHttpService::get_handler_print(httpd_req_t *req)
     }
     // WAS: A bit of a kludge for now: get printer from main routine
     // IS: now get printer emulator pointer from sioP (which is now extern)
-    printer_emu *currentPrinter = sioP.getPrinterPtr(); //getCurrentPrinter();
+    printer_emu *currentPrinter = printer->getPrinterPtr(); //getCurrentPrinter();
 
     // Build a print output name
     const char *exts;
@@ -344,7 +347,7 @@ esp_err_t fnHttpService::get_handler_print(httpd_req_t *req)
     // WAS:
     // currentPrinter->resetPrinter(); // resetOutput();
     // IS:
-    sioP.reset_printer(); // destroy,create new printer emulator object of previous type.
+    printer->reset_printer(); // destroy,create new printer emulator object of previous type.
 #ifdef DEBUG
     Debug_println("Print request completed");
 #endif

--- a/platformio/FujiNet/lib/http/httpServiceConfigurator.cpp
+++ b/platformio/FujiNet/lib/http/httpServiceConfigurator.cpp
@@ -133,7 +133,10 @@ void fnHttpServiceConfigurator::config_printer(std::string printernumber, std::s
     // Finally, change the printer type!
     Config.store_printer(0, t);
     Config.save();
-    sioP.set_printer_type(t);
+
+    // Get a pointer to the current (only) printer
+    sioPrinter *printer = (sioPrinter *)SIO.deviceById(SIO_DEVICEID_PRINTER);
+    printer->set_printer_type(t);
 }
 
 int fnHttpServiceConfigurator::process_config_post(const char * postdata, size_t postlen)

--- a/platformio/FujiNet/lib/http/httpServiceParser.cpp
+++ b/platformio/FujiNet/lib/http/httpServiceParser.cpp
@@ -135,7 +135,7 @@ const string fnHttpServiceParser::substitute_tag(const string &tag)
         resultstream << (float)fnSystem.get_sio_voltage()/1000.00 << "V";
         break;
     case FN_PRINTER1_MODEL:
-        resultstream << sioP.getPrinterPtr()->modelname();
+        resultstream << ((sioPrinter *)SIO.deviceById(SIO_DEVICEID_PRINTER))->getPrinterPtr()->modelname();
         break;
     default:
         resultstream << tag;

--- a/platformio/FujiNet/lib/printer-emulator/atari_1027.h
+++ b/platformio/FujiNet/lib/printer-emulator/atari_1027.h
@@ -1,6 +1,5 @@
 #ifndef ATARI_1027_H
 #define ATARI_1027_H
-#include <Arduino.h>
 
 #include "pdf_printer.h"
 

--- a/platformio/FujiNet/lib/printer-emulator/atari_820.cpp
+++ b/platformio/FujiNet/lib/printer-emulator/atari_820.cpp
@@ -1,0 +1,63 @@
+#include "atari_820.h"
+
+void atari820::initPrinter(FileSystem *fs)
+{
+    printer_emu::initPrinter(fs);
+
+    shortname = "a820";
+
+    pageWidth = 279.0;  // paper roll is 3 7/8" from page 6 of owners manual
+    pageHeight = 792.0; // just use 11" for letter paper
+    leftMargin = 19.5;  // fit print width on page width
+    bottomMargin = 0.0;
+    // dimensions from Table 1-1 of Atari 820 Field Service Manual
+    printWidth = 240.0; // 3 1/3" wide printable area
+    lineHeight = 12.0;  // 6 lines per inch
+    charWidth = 6.0;    // 12 char per inch
+    fontNumber = 1;
+    fontSize = 12;
+    sideFlag = false;
+
+    pdf_header();
+}
+
+void atari820::pdf_handle_char(byte c)
+{
+    // Atari 820 modes:
+    // aux1 == 40   normal mode
+    // aux1 == 29   sideways mode
+    if (my_sioP->_lastAux1 == 'N' && sideFlag)
+    {
+        fprintf(_file,")]TJ\n/F1 12 Tf [(");
+        fontNumber = 1;
+        fontSize = 12;
+        sideFlag = false;
+    }
+    else if (my_sioP->_lastAux1 == 'S' && !sideFlag)
+    {
+        fprintf(_file, ")]TJ\n/F2 12 Tf [(");
+        fontNumber = 2;
+        fontSize = 12;
+        sideFlag = true;
+        fontUsed[1] = true;
+        // could increase charWidth, but not necessary to make this work. I force EOL.
+    }
+
+    // maybe printable character
+    if (c > 31 && c < 127)
+    {
+        if (!sideFlag || c > 47)
+        {
+            if (c == ('\\') || c == '(' || c == ')')
+                fwrite("\\", 1, 1, _file);
+            fwrite(&c, 1, 1, _file);
+        }
+        else
+        {
+            if (c < 48)
+                fwrite(" ", 1, 1, _file);
+        }
+
+        pdf_X += charWidth; // update x position
+    }
+}

--- a/platformio/FujiNet/lib/printer-emulator/atari_820.h
+++ b/platformio/FujiNet/lib/printer-emulator/atari_820.h
@@ -1,0 +1,25 @@
+#ifndef _ATARI820_H
+#define _ATARI820_H
+
+#include "pdf_printer.h"
+#include "../sio/printer.h"
+
+class atari820 : public pdfPrinter
+{
+    // reverse the buffer in sioPrinter::sio_write() for sideways printing
+    // the PDF standard doesn't really handle right-to-left
+    // printing. The example in section 9.7 uses reverse strings.
+protected:
+    bool sideFlag = false;
+    sioPrinter *my_sioP; // added variable to point back to sioPrinter parent
+
+    void pdf_handle_char(byte c); // need a custom one to handle sideways printing
+
+public:
+    atari820(sioPrinter *P) { my_sioP = P; }
+    void initPrinter(FileSystem *fs);
+    // void setDevice(sioPrinter *P) { my_sioP = P; };
+    const char *modelname() { return "Atari 820"; };
+};
+
+#endif // _ATARI820_H

--- a/platformio/FujiNet/lib/printer-emulator/atari_822.cpp
+++ b/platformio/FujiNet/lib/printer-emulator/atari_822.cpp
@@ -1,0 +1,96 @@
+#include "atari_822.h"
+
+void atari822::initPrinter(FileSystem *fs)
+{
+    printer_emu::initPrinter(fs);
+
+    shortname = "a822";
+
+    pageWidth = 319.5;  // paper roll is 4 7/16" from page 4 of owners manual
+    pageHeight = 792.0; // just use 11" for letter paper
+    leftMargin = 15.75; // fit print width on page width
+    bottomMargin = 0.0;
+
+    printWidth = 288.0; // 4" wide printable area
+    lineHeight = 12.0;  // 6 lines per inch
+    charWidth = 7.2;    // 10 char per inch
+    fontNumber = 1;
+    fontSize = 12;
+
+    pdf_header();
+}
+
+void atari822::pdf_handle_char(byte c)
+{
+    // use PDF inline image to display line of graphics
+    /*
+  q
+  240 0 0 1 18 750 cm
+  BI
+  /W 240
+  /H 1
+  /CS /G
+  /BPC 1
+  /D [1 0]
+  /F /AHx
+  ID
+  00 00 00 00 00 00 3C 00 7E 00 7C 60 00 3C 00 18 3C 00 78 7C 18 63 7E 3C 00 7E 3C 00 18 3C
+  >
+  EI
+  Q
+  */
+
+    // Atari 822 modes:
+    // aux1 == 'N'   normal mode
+    // aux1 == 'L'   graphics mode
+
+    // was: if (cmdFrame.comnd == 'W' && !textMode)
+    if (my_sioP->_lastAux1 == 'N' && !textMode)
+    {
+        textMode = true;
+        pdf_begin_text(pdf_Y); // open new text object
+        pdf_new_line();        // start new line of text (string array)
+    }
+    // was: else if (cmdFrame.comnd == 'P' && textMode)
+    else if (my_sioP->_lastAux1 == 'L' && textMode)
+    {
+        textMode = false;
+        if (!BOLflag)
+            pdf_end_line();   // close out string array
+        fprintf(_file, "ET\n"); // close out text object
+    }
+
+    if (!textMode && BOLflag)
+    {
+        fprintf(_file, "q\n %g 0 0 %g %g %g cm\n", printWidth, lineHeight / 10.0, leftMargin, pdf_Y);
+        fprintf(_file, "BI\n /W 240\n /H 1\n /CS /G\n /BPC 1\n /D [1 0]\n /F /AHx\nID\n");
+        BOLflag = false;
+    }
+    if (!textMode)
+    {
+        if (gfxNumber < 30)
+            fprintf(_file, " %02X", c);
+
+        gfxNumber++;
+
+        if (gfxNumber == 40)
+        {
+            fprintf(_file, "\n >\nEI\nQ\n");
+            pdf_Y -= lineHeight / 10.0;
+            BOLflag = true;
+            gfxNumber = 0;
+        }
+    }
+
+    // TODO: looks like auto wrapped lines are 1 dot apart and EOL lines are 3 dots apart
+
+    // simple ASCII printer
+    if (textMode && c > 31 && c < 127)
+    {
+        if (c == '\\' || c == '(' || c == ')')
+            fwrite("\\", 1, 1, _file);
+        fwrite(&c, 1, 1, _file);
+
+        pdf_X += charWidth; // update x position
+    }
+}

--- a/platformio/FujiNet/lib/printer-emulator/atari_822.h
+++ b/platformio/FujiNet/lib/printer-emulator/atari_822.h
@@ -1,0 +1,24 @@
+#ifndef _ATARI822_H
+#define _ATARI822_H
+
+#include "pdf_printer.h"
+#include "../sio/printer.h"
+
+class atari822 : public pdfPrinter
+{
+protected:
+    sioPrinter *my_sioP;
+
+    void pdf_handle_char(byte c); // need a custom one to handle sideways printing
+
+    int gfxNumber = 0;
+
+public:
+    atari822(sioPrinter *P) { my_sioP = P; }
+    virtual void initPrinter(FileSystem *fs);
+    const char *modelname() { return "Atari 822"; };
+
+    //void setDevice(sioPrinter *P) { my_sioP = P; };
+};
+
+#endif // _ATARI822_H

--- a/platformio/FujiNet/lib/printer-emulator/pdf_printer.h
+++ b/platformio/FujiNet/lib/printer-emulator/pdf_printer.h
@@ -1,11 +1,7 @@
 #ifndef PDF_PRINTER_H
 #define PDF_PRINTER_H
 
-//#include <Arduino.h>
-
 #include <string>
-//#include <FS.h>
-//#include <SPIFFS.h>
 
 #include "printer_emulator.h"
 

--- a/platformio/FujiNet/lib/sio/sio.cpp
+++ b/platformio/FujiNet/lib/sio/sio.cpp
@@ -323,12 +323,13 @@ void sioBus::service()
 #endif
                     for (int i = 0; i < numDevices(); i++)
                     {
-                        if (device(i)->listen_to_type3_polls)
+                        sioDevice * siodev = deviceByIndex(i);                        
+                        if (siodev->listen_to_type3_polls)
                         {
 #ifdef DEBUG
-                            Debug_printf("Sending TYPE3 poll to dev %x\n", device(i)->_devnum);
+                            Debug_printf("Sending TYPE3 poll to dev %x\n", siodev->_devnum);
 #endif
-                            activeDev = device(i);
+                            activeDev = siodev;
                             for (int i = 0; i < 5; i++)
                                 activeDev->cmdFrame.cmdFrameData[i] = tempFrame.cmdFrameData[i]; // copy data to device's buffer
 
@@ -343,9 +344,10 @@ void sioBus::service()
                     // this is what sioBus::sio_get_id() does, but need to pass the tempFrame to it
                     for (int i = 0; i < numDevices(); i++)
                     {
-                        if (tempFrame.devic == device(i)->_devnum)
+                        sioDevice * siodev = deviceByIndex(i);
+                        if (tempFrame.devic == siodev->_devnum)
                         {
-                            activeDev = device(i);
+                            activeDev = siodev;
                             for (int i = 0; i < 5; i++)
                                 activeDev->cmdFrame.cmdFrameData[i] = tempFrame.cmdFrameData[i]; // copy data to device's buffer
 #ifdef ESP8266
@@ -448,7 +450,7 @@ void sioBus::addDevice(sioDevice *p, int N)
     {
         fujiDev = (sioFuji *)p;
     }
-    else if (N == ADDR_R)
+    else if (N == SIO_DEVICEID_RS232)
     {
 #ifdef DEBUG
         //Debug_println("MODEM ADDED!");
@@ -470,7 +472,7 @@ void sioBus::addDevice(sioDevice *p, int N)
 bool sioBus::remDevice(sioDevice *p)
 {
     int i = 0;
-    while (p != device(i))
+    while (p != daisyChain.get(i))
     {
         i++;
         if (i > numDevices())
@@ -485,9 +487,21 @@ int sioBus::numDevices()
     return daisyChain.size();
 }
 
-sioDevice *sioBus::device(int i)
+sioDevice *sioBus::deviceByIndex(int i)
 {
     return daisyChain.get(i);
+}
+
+sioDevice *sioBus::deviceById(int id)
+{
+    int l = daisyChain.size();
+    for(int i = 0; i < l; i++)
+    {
+        sioDevice *dev = daisyChain.get(i);
+        if(dev->_devnum == id)
+            return dev;
+    }
+    return nullptr;
 }
 
 int sioBus::getBaudrate()

--- a/platformio/FujiNet/lib/sio/sio.h
+++ b/platformio/FujiNet/lib/sio/sio.h
@@ -41,8 +41,8 @@
 #define CMD_TIMEOUT 50
 #define STATUS_SKIP 8
 
-#define ADDR_R 0x50
-#define ADDR_P 0x40
+//#define ADDR_R 0x50
+//#define ADDR_P 0x40
 
 #define SIO_DEVICEID_FUJINET 0x70
 #define SIO_DEVICEID_FN_NETWORK 0x71
@@ -118,7 +118,7 @@ private:
    sioDevice *activeDev = nullptr;
    sioModem *modemDev = nullptr;
    sioFuji *fujiDev = nullptr;
-   sioNetwork *netDev[8] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+   sioNetwork *netDev[8] = {nullptr};
 
    int sioBaud = 19200; // SIO Baud rate
 
@@ -129,7 +129,8 @@ public:
    void service();
    void addDevice(sioDevice *p, int N);
    bool remDevice(sioDevice *p);
-   sioDevice *device(int i);
+   sioDevice *deviceByIndex(int i);
+   sioDevice *deviceById(int id);
    int getBaudrate();
    void setBaudrate(int baudrate);
 };

--- a/platformio/FujiNet/src/main.cpp
+++ b/platformio/FujiNet/src/main.cpp
@@ -152,20 +152,16 @@ void setup()
 
     SIO.addDevice(&sioR, SIO_DEVICEID_RS232); // R:
 
-    // Choose filesystem for P: device and iniitalize it
-    if ( fnSDFAT.running() )//SD.cardType() != CARD_NONE)
-    {
-        Debug_println("using SD card for printer storage");
-        sioP.set_storage(&fnSDFAT);
-    }
-    else
-    {
-        Debug_println("using SPIFFS for printer storage");
-        sioP.set_storage(&fnSPIFFS);
-    }
-    sioP.set_printer_type(Config.get_printer_type(0));
-
-    SIO.addDevice(&sioP, SIO_DEVICEID_PRINTER); // P:
+    // Create a new printer object, setting its output depending on whether we have SD or not
+    FileSystem *ptrfs = fnSDFAT.running() ? (FileSystem *)&fnSDFAT : (FileSystem *)&fnSPIFFS;
+    sioPrinter::printer_type ptype = Config.get_printer_type(0);
+    if(ptype == sioPrinter::printer_type::PRINTER_INVALID)
+        ptype = sioPrinter::printer_type::PRINTER_FILE_TRIM;
+    #ifdef DEBUG
+        Debug_printf("Creating a default printer using %s storage and %d type\n", ptrfs->typestring(), ptype);
+    #endif        
+    sioPrinter *ptr = new sioPrinter(ptrfs, ptype);
+    SIO.addDevice(ptr, SIO_DEVICEID_PRINTER); // P:
 
     SIO.addDevice(&sioV, SIO_DEVICEID_FN_VOICE); // P3:
 


### PR DESCRIPTION
- Moved Atari820 and Atari822 into separate files to match the rest of the printer_emu classes
- Removed sioPrinter::set_storage() in favor of forcing storage specification during sioPrinter construction (so we're not needlessly re-creating the output file).
- Removed global sioPrinter object in favor of creating a new instance dynamically at startup
- Changed some variable names for consistency/readabilty
