### PR TITLE
Atari 825 - dot spacing

### DIFF
--- a/platformio/FujiNet/lib/printer-emulator/atari_825.cpp
+++ b/platformio/FujiNet/lib/printer-emulator/atari_825.cpp
@@ -93,24 +93,23 @@ void atari825::pdf_handle_char(uint8_t c, uint8_t aux1, uint8_t aux2)
 
             // TODO: fix this
             check_font();
+
+            if (epson_font_mask & fnt_proportional)
             {
-                int n = 7 - epson_cmd.cmd;
-                if (epson_font_mask & fnt_proportional)
-                {
-                    fprintf(_file, " )%d(", (int)(n * 40));
-                    pdf_X += 0.48 * (float)epson_cmd.cmd;
-                }
-                else if (epson_font_mask & fnt_compressed)
-                {
-                    fprintf(_file, " )%d(", (int)(n * 40)); // need correct value for 16.7 CPI
-                    pdf_X += 0.48 * (float)epson_cmd.cmd;
-                }
-                else
-                {
-                    fprintf(_file, " )%d(", (int)(n * 40)); // need correct value for 10 CPI
-                    pdf_X += 0.6 * (float)epson_cmd.cmd;
-                }
+                fprintf(_file, " )%d(", (int)(280 - epson_cmd.cmd * 40));
+                pdf_X += 0.48 * (float)epson_cmd.cmd;
             }
+            else if (epson_font_mask & fnt_compressed)
+            {
+                fprintf(_file, " )%d(", (int)(360 - epson_cmd.cmd * 40)); // need correct value for 16.7 CPI
+                pdf_X += 0.48 * (float)epson_cmd.cmd;
+            }
+            else
+            {
+                fprintf(_file, " )%d(", (int)(600 - epson_cmd.cmd * 60)); // need correct value for 10 CPI
+                pdf_X += 0.6 * (float)epson_cmd.cmd;
+            }
+
             reset_cmd();
             break;
         case 10:                  // full reverse line feed

--- a/platformio/FujiNet/lib/printer-emulator/atari_825.cpp
+++ b/platformio/FujiNet/lib/printer-emulator/atari_825.cpp
@@ -164,11 +164,10 @@ void atari825::pdf_handle_char(uint8_t c, uint8_t aux1, uint8_t aux2)
             // Prints buffer contents and resets buffer character count to zero
             // Implemented outside in pdf_printer()
             break;
-        case 14: // Turns on double width mode to end of line unless cancelled by 20
+        case 14: // Turns off underline
             clear_mode(fnt_underline);
             break;
-        case 15: // Turns on compressed character mode. Does not work with
-                 // emphasized mode. Stays on until cancelled by OC2 (18)
+        case 15: // Turns on underline
             set_mode(fnt_underline);
             break;
         case 27: // ESC mode

--- a/platformio/FujiNet/lib/printer-emulator/atari_825.h
+++ b/platformio/FujiNet/lib/printer-emulator/atari_825.h
@@ -34,6 +34,7 @@ protected:
     uint8_t epson_font_lookup(uint16_t code);
     float epson_font_width(uint16_t code);
     void epson_set_font(uint8_t F, float w);
+    void check_font();
 
     virtual void pdf_clear_modes() override{};
     void pdf_handle_char(uint8_t c, uint8_t aux1, uint8_t aux2) override;


### PR DESCRIPTION
Fixed logic error in dot spacing which caused the wrong font to be selected (proportional text was mistakenly underlined) when using Atari Writer.