### PR TITLE
Atari 825 backspace mode corrected

### DIFF
--- a/platformio/FujiNet/lib/printer-emulator/atari_825.cpp
+++ b/platformio/FujiNet/lib/printer-emulator/atari_825.cpp
@@ -154,13 +154,36 @@ void atari825::pdf_handle_char(uint8_t c, uint8_t aux1, uint8_t aux2)
             break;
         }
     }
+    else if (backMode)
+    {
+        // Backspace. Empties printer buffer, then backspaces N dot spaces
+        backMode = false; // update x position
+        check_font();
+        if (epson_font_mask & fnt_proportional)
+        {
+            // fprintf(_file, " )%d(", (int)(280 - epson_cmd.cmd * 40));
+            fprintf(_file, ")%d(", (int)(epson_cmd.cmd * 40));
+            pdf_X += 0.48 * (float)epson_cmd.cmd;
+        }
+        else if (epson_font_mask & fnt_compressed)
+        {
+            // fprintf(_file, " )%d(", (int)(360 - epson_cmd.cmd * 40)); // need correct value for 16.7 CPI
+            fprintf(_file, ")%d(", (int)(epson_cmd.cmd * 40));
+            pdf_X += 0.48 * (float)epson_cmd.cmd;
+        }
+        else
+        {
+            // fprintf(_file, " )%d(", (int)(600 - epson_cmd.cmd * 60)); // need correct value for 10 CPI
+            fprintf(_file, ")%d(", (int)(epson_cmd.cmd * 60));
+            pdf_X += 0.6 * (float)epson_cmd.cmd;
+        }
+    }
     else
     { // check for other commands or printable character
         switch (c)
         {
-        case 8:                                                            // Backspace. Empties printer buffer, then backspaces print head one space
-            fprintf(_file, ")%d(", (int)(charWidth / lineHeight * 1000.)); // TODO update for 825 font
-            pdf_X -= charWidth;                                            // update x position
+        case 8:
+            backMode = true;
             break;
         case 10:                  // Line Feed. Printer empties its buffer and does line feed at
                                   // current line spacing and Resets buffer pointer to zero

--- a/platformio/FujiNet/lib/printer-emulator/atari_825.cpp
+++ b/platformio/FujiNet/lib/printer-emulator/atari_825.cpp
@@ -162,20 +162,20 @@ void atari825::pdf_handle_char(uint8_t c, uint8_t aux1, uint8_t aux2)
         if (epson_font_mask & fnt_proportional)
         {
             // fprintf(_file, " )%d(", (int)(280 - epson_cmd.cmd * 40));
-            fprintf(_file, ")%d(", (int)(epson_cmd.cmd * 40));
-            pdf_X += 0.48 * (float)epson_cmd.cmd;
+            fprintf(_file, ")%d(", (int)(c * 40));
+            pdf_X -= 0.48 * (float)c;
         }
         else if (epson_font_mask & fnt_compressed)
         {
             // fprintf(_file, " )%d(", (int)(360 - epson_cmd.cmd * 40)); // need correct value for 16.7 CPI
-            fprintf(_file, ")%d(", (int)(epson_cmd.cmd * 40));
-            pdf_X += 0.48 * (float)epson_cmd.cmd;
+            fprintf(_file, ")%d(", (int)(c * 40));
+            pdf_X -= 0.48 * (float)c;
         }
         else
         {
             // fprintf(_file, " )%d(", (int)(600 - epson_cmd.cmd * 60)); // need correct value for 10 CPI
-            fprintf(_file, ")%d(", (int)(epson_cmd.cmd * 60));
-            pdf_X += 0.6 * (float)epson_cmd.cmd;
+            fprintf(_file, ")%d(", (int)(c * 60));
+            pdf_X -= 0.6 * (float)c;
         }
     }
     else

--- a/platformio/FujiNet/lib/printer-emulator/atari_825.cpp
+++ b/platformio/FujiNet/lib/printer-emulator/atari_825.cpp
@@ -156,7 +156,11 @@ void atari825::pdf_handle_char(uint8_t c, uint8_t aux1, uint8_t aux2)
     }
     else if (backMode)
     {
+#ifdef DEBUG
+        Debug_printf("backspace mode: %u\n", c);
+#endif
         // Backspace. Empties printer buffer, then backspaces N dot spaces
+        c &= 0x7F;        // ignore MSB
         backMode = false; // update x position
         check_font();
         if (epson_font_mask & fnt_proportional)

--- a/platformio/FujiNet/lib/printer-emulator/atari_825.cpp
+++ b/platformio/FujiNet/lib/printer-emulator/atari_825.cpp
@@ -107,7 +107,7 @@ void atari825::pdf_handle_char(uint8_t c, uint8_t aux1, uint8_t aux2)
             else
             {
                 fprintf(_file, " )%d(", (int)(600 - epson_cmd.cmd * 60)); // need correct value for 10 CPI
-                pdf_X += 0.6 * (float)epson_cmd.cmd;
+                pdf_X += 0.72 * (float)epson_cmd.cmd;
             }
 
             reset_cmd();
@@ -179,7 +179,7 @@ void atari825::pdf_handle_char(uint8_t c, uint8_t aux1, uint8_t aux2)
         {
             // fprintf(_file, " )%d(", (int)(600 - epson_cmd.cmd * 60)); // need correct value for 10 CPI
             fprintf(_file, ")%d(", (int)(c * 60));
-            pdf_X -= 0.6 * (float)c;
+            pdf_X -= 0.72 * (float)c;
         }
     }
     else

--- a/platformio/FujiNet/lib/printer-emulator/atari_825.h
+++ b/platformio/FujiNet/lib/printer-emulator/atari_825.h
@@ -17,6 +17,7 @@ protected:
         uint16_t ctr;
     } epson_cmd = {0, 0, 0, 0};
     bool escMode = false;
+    bool backMode = false;
 
     const uint16_t fnt_underline = 0x001;
     const uint16_t fnt_expanded = 0x002;


### PR DESCRIPTION
implemented proper command/arg format for Atari 825 backspace mode. Corrected pdf_X coordinate updating for dot spacing and backspacing. Tested with some BASIC demo commands from manual